### PR TITLE
Fix 'intercom' package definition and add it as dependency

### DIFF
--- a/catkin_home/src/action_selectors/CMakeLists.txt
+++ b/catkin_home/src/action_selectors/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   audio_common_msgs
+  intercom
 )
 
 ## System dependencies are found with CMake's conventions

--- a/catkin_home/src/intercom/CMakeLists.txt
+++ b/catkin_home/src/intercom/CMakeLists.txt
@@ -105,7 +105,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   #INCLUDE_DIRS include
-  LIBRARIES intercom
+  #LIBRARIES a_lib
   CATKIN_DEPENDS roscpp rospy std_msgs message_runtime
   #DEPENDS system_lib
 )

--- a/catkin_home/src/main_engine/CMakeLists.txt
+++ b/catkin_home/src/main_engine/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   message_generation
+  intercom
 )
 
 ## System dependencies are found with CMake's conventions


### PR DESCRIPTION
Fix CMakeList.txt of the package `intercom` to remove in the `catkin_package()` the incorrect set of "intercom" as an exported created library, because that package is not creating any library. After this, add in the dependant `main_engine` and `action_selectors` the actual depency with `find_package()` to `intercom`. 
This fixes to be able to correctly build without errors the workspace with `catkin build` command.

For more information with a correct example check [this question](https://answers.ros.org/question/336841/find_package-unable-to-find-packages-that-ive-created-in-the-workspace/); important to also say that packages created inside the same workspace do need anyway to be `find_packages()`ed as other "system" packages.

Another thing is that I am not sure if is correct to also put a `<build_export_depend>intercom</build_export_depend>` in the package.xml.